### PR TITLE
fix css issue

### DIFF
--- a/archetype/config/index.js
+++ b/archetype/config/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  webpack: {
+    cssModuleSupport: false
+  }
+};

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "electrode-server": "^1.0.0",
     "electrode-static-paths": "^1.0.0",
     "lodash": "^4.10.1",
-    "swagger-ui-dist": "^3.13.6"
+    "swagger-ui": "^3.14.0"
   },
   "devDependencies": {
     "electrode-archetype-react-app-dev": "^5.0.0"

--- a/src/client/components/spec.jsx
+++ b/src/client/components/spec.jsx
@@ -1,52 +1,43 @@
-import React from 'react';
-import PropTypes from 'prop-types';
-import getSpec from './sample_spec.json';
-import SwaggerUi, {presets} from 'swagger-ui';
-//import divStyles from "../styles/swagger.css";
-import 'swagger-ui/dist/swagger-ui.css';
-
+import React from "react";
+import PropTypes from "prop-types";
+import getSpec from "./sample_spec.json";
+import SwaggerUi, { presets } from "swagger-ui";
+import "swagger-ui/dist/swagger-ui.css";
 
 class SwaggerUI extends React.Component {
+  componentDidMount() {
+    SwaggerUi({
+      dom_id: "#swaggerContainer",
+      url: this.props.url,
+      spec: this.props.spec,
+      presets: [presets.apis]
+    });
+  }
 
-    componentDidMount() {
-        SwaggerUi({
-            dom_id: '#swaggerContainer',
-            url: this.props.url,
-            spec: this.props.spec,
-            presets: [presets.apis]
-        });
-    }
-
-    render() {
-        return (
-            <div id="swaggerContainer" />
-        );
-    }
+  render() {
+    return <div id="swaggerContainer" />;
+  }
 }
 
 SwaggerUI.propTypes = {
-    url: PropTypes.string,
-    spec: PropTypes.object
+  url: PropTypes.string,
+  spec: PropTypes.object
 };
 
 SwaggerUI.defaultProps = {
-    url: `http://petstore.swagger.io/v2/swagger.json`
+  url: `http://petstore.swagger.io/v2/swagger.json`
 };
 
 class Spec extends React.Component {
+  render() {
+    //const sample_spec = getSpec;style={divStyles}
 
-    render() {
-
-        //const sample_spec = getSpec;style={divStyles}
-
-        return (
-            <div >
-                <SwaggerUI
-                  spec={getSpec}
-                />
-            </div>
-        )
-    }
+    return (
+      <div>
+        <SwaggerUI spec={getSpec} />
+      </div>
+    );
+  }
 }
 
 export default Spec;


### PR DESCRIPTION
As i early referred, electrode archetype styles is taking css modules as default.
The swagger-ui.css here is a pure css instead of css modules. css is encrypted because of the css-modules, so you need to disable it by `cssModuleSupport: false`.

Please read: https://github.com/css-modules/css-modules and how to extend webpack config: https://docs.electrode.io/chapter1/intermediate/app-archetype/